### PR TITLE
refine reparameter and act layer

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -639,6 +639,11 @@ class Trainer(object):
 
         if hasattr(self.model, 'deploy'):
             self.model.deploy = True
+
+        for layer in self.model.sublayers():
+            if hasattr(layer, 'convert_to_deploy'):
+                layer.convert_to_deploy()
+
         export_post_process = self.cfg.get('export_post_process', False)
         if hasattr(self.model, 'export_post_process'):
             self.model.export_post_process = export_post_process

--- a/ppdet/modeling/necks/custom_pan.py
+++ b/ppdet/modeling/necks/custom_pan.py
@@ -193,12 +193,6 @@ class CustomCSPPAN(nn.Layer):
 
         return pan_feats[::-1]
 
-    def eval(self):
-        self.training = False
-        for layer in self.sublayers():
-            layer.training = False
-            layer.eval()
-
     @classmethod
     def from_config(cls, cfg, input_shape):
         return {'in_channels': [i.channels for i in input_shape], }

--- a/ppdet/modeling/ops.py
+++ b/ppdet/modeling/ops.py
@@ -25,24 +25,52 @@ from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype
 
 __all__ = [
-    'roi_pool',
-    'roi_align',
-    'prior_box',
-    'generate_proposals',
-    'iou_similarity',
-    'box_coder',
-    'yolo_box',
-    'multiclass_nms',
-    'distribute_fpn_proposals',
-    'collect_fpn_proposals',
-    'matrix_nms',
-    'batch_norm',
-    'mish',
+    'roi_pool', 'roi_align', 'prior_box', 'generate_proposals',
+    'iou_similarity', 'box_coder', 'yolo_box', 'multiclass_nms',
+    'distribute_fpn_proposals', 'collect_fpn_proposals', 'matrix_nms',
+    'batch_norm', 'mish', 'swish', 'identity'
 ]
 
 
+def identity(x):
+    return x
+
+
 def mish(x):
-    return F.mish(x)
+    return F.mish(x) if hasattr(F, mish) else x * F.tanh(F.softplus(x))
+
+
+def swish(x):
+    return x * F.sigmoid(x)
+
+
+TRT_ACT_SPEC = {'swish': swish}
+
+ACT_SPEC = {'mish': mish}
+
+
+def get_act_fn(act=None, trt=False):
+    assert act is None or isinstance(act, (
+        str, dict)), 'name of activation should be str, dict or None'
+    if not act:
+        return identity
+
+    if isinstance(act, dict):
+        name = act['name']
+        act.pop('name')
+        kwargs = act
+    else:
+        name = act
+        kwargs = dict()
+
+    if trt and name in TRT_ACT_SPEC:
+        fn = TRT_ACT_SPEC[name]
+    elif name in ACT_SPEC:
+        fn = ACT_SPEC[name]
+    else:
+        fn = getattr(F, name)
+
+    return lambda x: fn(x, **kwargs)
 
 
 def batch_norm(ch,


### PR DESCRIPTION
1. refine重参数化的代码，将会在deploy的时候自动重参数化
2. refine激活函数的代码，针对转trt时需要将激活函数拆分成细粒度op的函数，定义在ppdet/modeling/ops.py的TRT_ACT_SPEC中，导出模型的时候需要指定-o trt=true
3. 在custom_pan中重写SPP，避免其使用yolo_fpn.py中的SPP模块以至于使用darknet的ConvBN层